### PR TITLE
🐞🐛 Fix unexpected js behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 .DS_Store
+coverage/coverage-final.json

--- a/README.md
+++ b/README.md
@@ -23,3 +23,7 @@ Docs are written in the files themselves:
 -   [`solveInverseKinematics`](./src/solvers/ik/hexapodSolver.js)
 
 You can also inspect the [test directory](https://github.com/mithi/hexapod-kinematics-library/tree/main/tests) to see examples of how they're used.
+
+## Contributing [![PRs welcome!](https://img.shields.io/badge/PRs-welcome-orange.svg?style=flat)](https://github.com/mithi/mithi/wiki/Contributing)
+
+Please read the [contributing guidelines](https://github.com/mithi/mithi/wiki/Contributing) and the recommended [commit style guide](https://github.com/mithi/mithi/wiki/Commit-style-guide)! Thanks!

--- a/src/VirtualHexapod.js
+++ b/src/VirtualHexapod.js
@@ -160,6 +160,7 @@ class VirtualHexapod {
         // - new orientation of the body (nAxis)
         // - which legs are on the ground (groundLegsNoGravity)
         // - distance of center of gravity to the ground (height)
+
         const solved = flags.assumeKnownGroundPoints
             ? oSolverSpecific.computeOrientationProperties(legsNoGravity)
             : oSolverGeneral.computeOrientationProperties(legsNoGravity)

--- a/src/index.js
+++ b/src/index.js
@@ -2,5 +2,12 @@ import VirtualHexapod from "./VirtualHexapod"
 import getWalkSequence from "./solvers/walkSequenceSolver"
 import solveInverseKinematics from "./solvers/ik/hexapodSolver"
 import { POSITION_NAMES_LIST } from "./constants"
+import { tRotZmatrix } from "./geometry"
 
-export { VirtualHexapod, getWalkSequence, solveInverseKinematics, POSITION_NAMES_LIST }
+export {
+    VirtualHexapod,
+    getWalkSequence,
+    solveInverseKinematics,
+    POSITION_NAMES_LIST,
+    tRotZmatrix,
+}

--- a/src/solvers/ik/LinkageIKSolver.js
+++ b/src/solvers/ik/LinkageIKSolver.js
@@ -167,7 +167,6 @@ class LinkageIKSolver {
         }
 
         if (pars + femur < tibia) {
-            console.log(this.info.legPosition)
             this.info = LegIKInfo.tibiaTooLong(this.legPosition)
             return
         }

--- a/src/solvers/orient/orientSolverGeneral.js
+++ b/src/solvers/orient/orientSolverGeneral.js
@@ -8,7 +8,7 @@ that are not handled correctly by the orientSolverSpecific.
 algorithm is available.
 
 ............
-  OVERVIEW
+    OVERVIEW
 ............
 
 Find:
@@ -23,16 +23,16 @@ We have 18 points total.
 
 We have a total of 540 combinations
 - get three legs out of six (20 combinations)
-  - we have three possible points for each leg,
+    - we have three possible points for each leg,
         (coxiaPoint, femurPoint, footTip),
         that's 27 (3^3) combinations
-  -  27 * 20 is 540
+    -  27 * 20 is 540
 
 For each combination:
     1. Check if stable. If not, try the next combination
-      - Check if the projection of the center of gravity to the plane
-        defined by the three points lies inside the triangle,
-        if not stable, try the next combination
+        - Check if the projection of the center of gravity to the plane
+            defined by the three points lies inside the triangle,
+            if not stable, try the next combination
 
     2. Get the HEIGHT and normal of the height and normal of the triangle plane
         (We need this for the next part)
@@ -154,7 +154,7 @@ const getThreePoints = (threeLegs, threeJointIndices) =>
 
 const getTwoLegSets = (threeLegIndices, sixLegs) => {
     const threeLegs = threeLegIndices.map(n => sixLegs[n])
-    const otherThreeLegIndices = [...Array(6).keys()].filter(
+    const otherThreeLegIndices = [0, 1, 2, 3, 4, 5].filter(
         n => !threeLegIndices.includes(n)
     )
     const otherThreeLegs = otherThreeLegIndices.map(n => sixLegs[n])


### PR DESCRIPTION
- Testing with a separate app: https://github.com/mithi/hexapod-irl, I found out `[...Array(6).keys()].filter` wasn't working as expected, so I replaced it with `[0, 1, 2, 3, 4, 5].filter( n => !threeLegIndices.includes(n))`
- In the tests `[...Array(6).keys()]` returns an array but in production it returns an `iterator`. I don't know why. 
- Expose rotate z matrix function as it is used by above mentioned app
- Fixed format of comments
- Update README
